### PR TITLE
Add basic event listener for jobs processed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
         }
     ],
     "require": {
+        "illuminate/cache": "~5.8",
+        "illuminate/contracts": "~5.8",
+        "illuminate/events": "~5.8",
+        "illuminate/queue": "~5.8",
+        "illuminate/support": "~5.8"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",

--- a/config/drillsergeant.php
+++ b/config/drillsergeant.php
@@ -16,4 +16,15 @@ return [
 
     'cache_store' => env('DRILL_SERGEANT_CACHE_STORE', 'file'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This option changes the prefix added to all cache items managed by this
+    | package.
+    |
+    */
+
+    'cache_prefix' => env('DRILL_SERGEANT_CACHE_PREFIX', 'drillsergeant'),
 ];

--- a/src/Listeners/IncrementJobCount.php
+++ b/src/Listeners/IncrementJobCount.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DrillSergeant\Listeners;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Queue\Events\JobProcessed;
+
+class IncrementJobCount
+{
+    /**
+     * Update the metrics cache with a new job increment.
+     *
+     * @var JobProcessed $event
+     */
+    public function handle(JobProcessed $event)
+    {
+        $cache = Cache::store(config('drillsergeant.cache_store'));
+
+        if (!$cache->has($this->getCacheKey($event->job->getQueue()))) {
+            // laravel has a bug in some cache drivers that means `forever()` can't be used
+            $cache->put($this->getCacheKey($event->job->getQueue()), 1, now()->addYears(5)->getTimestamp());
+        } else {
+            $cache->increment($this->getCacheKey($event->job->getQueue()));
+        }
+    }
+
+    protected function getCacheKey(string $name)
+    {
+        return config('drillsergeant.cache_prefix') . ":${name}";
+    }
+}

--- a/src/Listeners/IncrementJobCount.php
+++ b/src/Listeners/IncrementJobCount.php
@@ -15,17 +15,18 @@ class IncrementJobCount
     public function handle(JobProcessed $event)
     {
         $cache = Cache::store(config('drillsergeant.cache_store'));
+        $job = $event->job;
 
-        if (!$cache->has($this->getCacheKey($event->job->getQueue()))) {
+        if (!$cache->has($this->getCacheKey($job->getQueue(), $job->resolveName()))) {
             // laravel has a bug in some cache drivers that means `forever()` can't be used
-            $cache->put($this->getCacheKey($event->job->getQueue()), 1, now()->addYears(5)->getTimestamp());
+            $cache->put($this->getCacheKey($job->getQueue(), $job->resolveName()), 1, now()->addYears(5)->getTimestamp());
         } else {
-            $cache->increment($this->getCacheKey($event->job->getQueue()));
+            $cache->increment($this->getCacheKey($job->getQueue(), $job->resolveName()));
         }
     }
 
-    protected function getCacheKey(string $name)
+    protected function getCacheKey(string $queue, string $job)
     {
-        return config('drillsergeant.cache_prefix') . ":${name}";
+        return config('drillsergeant.cache_prefix') . ":${queue}:${job}";
     }
 }

--- a/src/Listeners/IncrementJobCount.php
+++ b/src/Listeners/IncrementJobCount.php
@@ -19,7 +19,14 @@ class IncrementJobCount
 
         if (!$cache->has($this->getCacheKey($job->getQueue(), $job->resolveName()))) {
             // laravel has a bug in some cache drivers that means `forever()` can't be used
-            $cache->put($this->getCacheKey($job->getQueue(), $job->resolveName()), 1, now()->addYears(5)->getTimestamp());
+            $cache->put(
+                $this->getCacheKey(
+                    $job->getQueue(),
+                    $job->resolveName()
+                ),
+                1,
+                now()->addYears(5)->getTimestamp()
+            );
         } else {
             $cache->increment($this->getCacheKey($job->getQueue(), $job->resolveName()));
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace DrillSergeant;
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Illuminate\Queue\Events\JobProcessed;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -14,14 +16,7 @@ class ServiceProvider extends BaseServiceProvider
     public function boot()
     {
         $this->publishes([__DIR__ . '/../config/drillsergeant.php' => config_path('drillsergeant.php')]);
-    }
 
-    /**
-     * Register bindings in the container.
-     *
-     * @return void
-     */
-    public function register()
-    {
+        Event::listen(JobProcessed::class, Listeners\IncrementJobCount::class);
     }
 }

--- a/tests/Listeners/IncrementJobCountTest.php
+++ b/tests/Listeners/IncrementJobCountTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace DrillSergeant\Tests;
+
+use DrillSergeant\ServiceProvider;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Jobs\SyncJob;
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\TestCase;
+
+class IncrementJobCountTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // configure an array cache to test with
+        config([
+            'drillsergeant.cache_store' => 'array',
+            'drillsergeant.cache_prefix' => 'drillsergeant',
+        ]);
+    }
+
+    public function testHandleJobEmptyCache()
+    {
+        // dispatch the event
+        $job = new SyncJob(app(), json_encode(['job' => 'test']), 'test-connection', null);
+        event(new JobProcessed('test-connection', $job));
+
+        // assert the cache contains the correct keys
+        $this->assertEquals(1, Cache::get('drillsergeant:sync:test'));
+    }
+
+    public function testHandleJobExistingCache()
+    {
+        // put an existing count into the cache
+        Cache::put('drillsergeant:sync:test', 42, 9999);
+
+        // dispatch the event
+        $job = new SyncJob(app(), json_encode(['job' => 'test']), 'test-connection', null);
+        event(new JobProcessed('test-connection', $job));
+
+        // assert the cache contains the correct keys
+        $this->assertEquals(43, Cache::get('drillsergeant:sync:test'));
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [ServiceProvider::class];
+    }
+}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DrillSergeant\Tests;
+
+use DrillSergeant\ServiceProvider;
+use Illuminate\Queue\Events\JobProcessed;
+use Orchestra\Testbench\TestCase;
+
+class ServiceProviderTest extends TestCase
+{
+    public function testEventsListenedTo()
+    {
+        $this->assertCount(1, app('events')->getListeners(JobProcessed::class));
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [ServiceProvider::class];
+    }
+}


### PR DESCRIPTION
This PR adds functionality to increment a counter in the cache when a job is finished processing