### PR TITLE
Add atomic locks to update the cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: php
+services:
+  - redis-server
 
 php:
   - 7.2

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
         "phpunit/phpunit": "^8.1",
-        "orchestra/testbench": "^3.8"
+        "orchestra/testbench": "^3.8",
+        "predis/predis": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/config/drillsergeant.php
+++ b/config/drillsergeant.php
@@ -10,7 +10,8 @@ return [
     | This option controls the default cache connection that gets used for
     | storing metrics data.
     |
-    | Supports any laravel cache store configured in your config/cache.php.
+    | Supports any laravel cache store that also supports locking, these are
+    | currently redis, memcached and dynamodb.
     |
     */
 
@@ -27,4 +28,16 @@ return [
     */
 
     'cache_prefix' => env('DRILL_SERGEANT_CACHE_PREFIX', 'drillsergeant'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Lock Timeout
+    |--------------------------------------------------------------------------
+    |
+    | This option sets the time in seconds to wait for an atomic lock to update
+    | the statistics stored in the cache.
+    |
+    */
+
+    'cache_lock_timeout' => env('DRILL_SERGEANT_CACHE_LOCK_TIMEOUT', 1),
 ];

--- a/src/Listeners/IncrementJobCount.php
+++ b/src/Listeners/IncrementJobCount.php
@@ -2,11 +2,28 @@
 
 namespace DrillSergeant\Listeners;
 
-use Illuminate\Support\Facades\Cache;
+use Exception;
+use Illuminate\Cache\CacheManager;
 use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Support\Facades\Log;
 
 class IncrementJobCount
 {
+    protected const CACHE_KEY_MONITORED_JOBS = 'monitored';
+    protected const CACHE_KEY_LOCK = 'drillsergeant:lock';
+
+    /** @var Repository */
+    protected $cache;
+
+    /** @var int */
+    protected $lockTimeout;
+
+    public function __construct(CacheManager $cache)
+    {
+        $this->cache = $cache->store(config('drillsergeant.cache_store'));
+        $this->lockTimeout = config('drillsergeant.cache_lock_timeout');
+    }
+
     /**
      * Update the metrics cache with a new job increment.
      *
@@ -14,22 +31,49 @@ class IncrementJobCount
      */
     public function handle(JobProcessed $event)
     {
-        $cache = Cache::store(config('drillsergeant.cache_store'));
         $job = $event->job;
+        $cacheKey = $this->getCacheKey($job->getQueue(), $job->resolveName());
 
-        if (!$cache->has($this->getCacheKey($job->getQueue(), $job->resolveName()))) {
-            // laravel has a bug in some cache drivers that means `forever()` can't be used
-            $cache->put(
-                $this->getCacheKey(
-                    $job->getQueue(),
-                    $job->resolveName()
-                ),
-                1,
-                now()->addYears(5)->getTimestamp()
-            );
+        // get the cache items storing which jobs are monitored and the current jobs counter
+        $cacheItems = $this->cache->many([static::CACHE_KEY_MONITORED_JOBS, $cacheKey]);
+
+        // if either the job counter is not set, or the current job is not in the list of monitored jobs, we need to
+        // use a lock to update the respective one (or both)
+        if ($this->cacheNeedsUpdatingUsingLock($cacheItems, $cacheKey)) {
+            try {
+                // update the cache key using an atomic lock
+                $this->cache
+                    ->lock(static::CACHE_KEY_LOCK)
+                    ->block($this->lockTimeout, function () use ($cacheKey) {
+                        // re-read the values inside the lock in case they changed
+                        $cacheItems = $this->cache->many([static::CACHE_KEY_MONITORED_JOBS, $cacheKey]);
+
+                        // update/set the counter
+                        $cacheItems[$cacheKey] += 1;
+                        // append this job to the list
+                        $cacheItems[static::CACHE_KEY_MONITORED_JOBS] = collect($cacheItems[static::CACHE_KEY_MONITORED_JOBS])
+                            ->push($cacheKey)
+                            ->unique()
+                            ->toArray();
+
+                        // put values into cache
+                        // NB: laravel has a bug in some cache drivers that means `forever()` can't be used
+                        $this->cache->putMany($cacheItems, now()->addMinutes(5)->getTimestamp());
+                    });
+            } catch (Exception $exception) {
+                Log::error('Failed to update metrics cache using atomic lock', ['exception' => $exception]);
+            }
         } else {
-            $cache->increment($this->getCacheKey($job->getQueue(), $job->resolveName()));
+            // otherwise we just need to increment the counter
+            // (because current job is monitored and counter already exists)
+            $this->cache->increment($cacheKey);
         }
+    }
+
+    protected function cacheNeedsUpdatingUsingLock($cacheItems, $jobCacheKey)
+    {
+        return !in_array($jobCacheKey, $cacheItems[static::CACHE_KEY_MONITORED_JOBS] ?? [])
+            || $cacheItems[$jobCacheKey] === null;
     }
 
     protected function getCacheKey(string $queue, string $job)

--- a/src/Listeners/IncrementJobCount.php
+++ b/src/Listeners/IncrementJobCount.php
@@ -51,7 +51,8 @@ class IncrementJobCount
                         // update/set the counter
                         $cacheItems[$cacheKey] += 1;
                         // append this job to the list
-                        $cacheItems[static::CACHE_KEY_MONITORED_JOBS] = collect($cacheItems[static::CACHE_KEY_MONITORED_JOBS])
+                        $cacheItems[static::CACHE_KEY_MONITORED_JOBS] =
+                            collect($cacheItems[static::CACHE_KEY_MONITORED_JOBS])
                             ->push($cacheKey)
                             ->unique()
                             ->toArray();

--- a/tests/Listeners/IncrementJobCountTest.php
+++ b/tests/Listeners/IncrementJobCountTest.php
@@ -16,12 +16,50 @@ class IncrementJobCountTest extends TestCase
 
         // configure an array cache to test with
         config([
-            'drillsergeant.cache_store' => 'array',
+            'drillsergeant.cache_store' => 'redis',
             'drillsergeant.cache_prefix' => 'drillsergeant',
         ]);
+
+        Cache::setDefaultDriver('redis');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Cache::store('redis')->flush();
     }
 
     public function testHandleJobEmptyCache()
+    {
+        // put an existing count into the cache
+        Cache::put('monitored', ['drillsergeant:sync:test'], 9999);
+
+        // dispatch the event
+        $job = new SyncJob(app(), json_encode(['job' => 'test']), 'test-connection', null);
+        event(new JobProcessed('test-connection', $job));
+
+        // assert the cache contains the correct values
+        $this->assertEquals(1, Cache::get('drillsergeant:sync:test'));
+        $this->assertEquals(['drillsergeant:sync:test'], Cache::get('monitored'));
+    }
+
+    public function testHandleJobExistingCache()
+    {
+        // put an existing count into the cache
+        Cache::put('drillsergeant:sync:test', 42, 9999);
+        Cache::put('monitored', ['drillsergeant:sync:test'], 9999);
+
+        // dispatch the event
+        $job = new SyncJob(app(), json_encode(['job' => 'test']), 'test-connection', null);
+        event(new JobProcessed('test-connection', $job));
+
+        // assert the cache contains the correct keys
+        $this->assertEquals(43, Cache::get('drillsergeant:sync:test'));
+        $this->assertEquals(['drillsergeant:sync:test'], Cache::get('monitored'));
+    }
+
+    public function testHandleJobEmptyCacheNoMonitoredMetrics()
     {
         // dispatch the event
         $job = new SyncJob(app(), json_encode(['job' => 'test']), 'test-connection', null);
@@ -29,9 +67,10 @@ class IncrementJobCountTest extends TestCase
 
         // assert the cache contains the correct keys
         $this->assertEquals(1, Cache::get('drillsergeant:sync:test'));
+        $this->assertEquals(['drillsergeant:sync:test'], Cache::get('monitored'));
     }
 
-    public function testHandleJobExistingCache()
+    public function testHandleJobExistingCacheNoMonitoredMetrics()
     {
         // put an existing count into the cache
         Cache::put('drillsergeant:sync:test', 42, 9999);
@@ -42,6 +81,40 @@ class IncrementJobCountTest extends TestCase
 
         // assert the cache contains the correct keys
         $this->assertEquals(43, Cache::get('drillsergeant:sync:test'));
+        $this->assertEquals(['drillsergeant:sync:test'], Cache::get('monitored'));
+    }
+
+    public function testMultipleJobs()
+    {
+        // put an existing count into the cache
+        Cache::put('drillsergeant:sync:test', 42, 9999);
+
+        // dispatch the event
+        $job = new SyncJob(app(), json_encode(['job' => 'test']), 'test-connection', null);
+        event(new JobProcessed('test-connection', $job));
+        $job = new SyncJob(app(), json_encode(['job' => 'test2']), 'test-connection', null);
+        event(new JobProcessed('test-connection', $job));
+
+        // assert the cache contains the correct keys
+        $this->assertEquals(43, Cache::get('drillsergeant:sync:test'));
+        $this->assertEquals(1, Cache::get('drillsergeant:sync:test2'));
+        $this->assertEquals(['drillsergeant:sync:test', 'drillsergeant:sync:test2'], Cache::get('monitored'));
+    }
+
+    public function testLockAlreadyAcquired()
+    {
+        // set the timeout to 0 so we don't block long tests
+        config(['drillsergeant.cache_lock_timeout' => 0]);
+        // put a lock in place to simulate another process having the lock
+        Cache::lock('drillsergeant:lock', 15)->acquire();
+
+        // dispatch the event
+        $job = new SyncJob(app(), json_encode(['job' => 'test']), 'test-connection', null);
+        event(new JobProcessed('test-connection', $job));
+
+        // assert the cache was not updated
+        $this->assertNull(Cache::get('drillsergeant:sync:test'));
+        $this->assertNull(Cache::get('monitored'));
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
This should remove any conditions where multiple processes try to update the metrics at the same time